### PR TITLE
[API Guides][Credentials] Changed contents based on VC API updates

### DIFF
--- a/guides/api-guides/credentials/credential-schemas.md
+++ b/guides/api-guides/credentials/credential-schemas.md
@@ -99,7 +99,7 @@ POST /schemas
     "schema_json": {json_schema}
     "organization_ids" : [{organisation_id}, ...]
   }
-}
+}`
 
 * `name` – Name of the credential schema
 * `json_schema` - JSON schema file

--- a/guides/api-guides/credentials/credential-schemas.md
+++ b/guides/api-guides/credentials/credential-schemas.md
@@ -21,32 +21,58 @@ Each VC JSON Schema consists of the following mandatory attributes:
 - JSON Schema – Object that describes the schema the credential is validated against.
 
 [JSON schemas](https://json-schema.org/) are plain JSON objects that cosist of following mandatory attributes (at the top level):
-- `$schema` - The schema specification used (e.g. `https://json-schema.org/draft/2019-09/schema`)
-- `required` – Array of required properties. Array MUST include `id`.
-- `additionalProperties` – MUST be `false`
+- `$schema` - The schema specification used (e.g. `https://json-schema.org/draft/2020-12/schema`)
+- `required` – Array of required properties.
 - `type` – MUST be `object`
+- `additionalProperties` - MUST be `true`
 
 Below is an example JSON schema. Note that all the attributes contained within a JSON schema will be used to form a credential. Attributes can be customised, and those that appear in the example below are indicative of possible options.
 
 ```bash
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "title": "Example",
-  "description": "Example",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Example title",
+  "description": "Example description",
   "type": "object",
   "properties": {
-    "id": {
+    "student_id": {
       "type": "string",
     }
   },
-  "required": ["id"],
-  "additionalProperties": false,
+  "required": ["student_id"],
+  "additionalProperties": true
 }
 ```
 
-Note that the `$id` property of the JSON Schema is set by the platform. When one is present in the schema, it will be overridden.
+Note that the `$id` property of the JSON Schema is set by the platform. When one is present in the schema, it will be overridden.  
+Note that if the format is `jwt_vc_json`, you need to define `credentialSubject` and store claims under it.  
+Here's the example of credential schema for `jwt_vc_json`.
 
-Also note that `https://json-schema.org/draft/2020-12/schema` is not supported at this point in time.
+```bash
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Example title",
+  "description": "Example description",
+  "type": "object",
+  "properties": {
+    "credentialSubject": {
+      "type": "object",
+      "properties": {
+        "student_id": {
+        "type": "string",
+        }
+      },
+      "required": [
+        "student_id"
+      ],
+      "additionalProperties": true
+    },
+  },
+  "required": [
+    "credentialSubject"
+  ]
+}
+```
 
 ## Who can undertake this operation?
 
@@ -66,11 +92,18 @@ Creation of a credential schema.
 POST /schemas
 ```
 
-**Request**
+**Request body**
+```bash
+{ "schema":
+  { "name":{name},
+    "schema_json": {json_schema}
+    "organization_ids" : [{organisation_id}, ...]
+  }
+}
 
-* Name – Name of the credential schema
-* JSON Schema - JSON schema file
-* List of organisations - Organisations where this credential schema can be used (optional)
+* `name` – Name of the credential schema
+* `json_schema` - JSON schema file
+* `organisation_id` - Organisations where this credential schema can be used (optional)
 
 **Response**
 
@@ -87,8 +120,8 @@ GET /schemas
  ```
 
 **Request**
-
-* Organisation (header)
+Include the following in the header section.  
+* `Meeco-Organisation-ID` - An organisation ID where schemas are available to.  
 
 **Response**
 
@@ -107,15 +140,26 @@ Note that in this version, the schema cannot be updated.
 ```bash
 PUT /schemas/{id}
  ```
-**Request**
 
-* The ID of the credential schema
-* Name – Name of the credential schema
-* List of organisations - Organisations where this credential schema can be used (optional)
+**Request**
+* id - The ID of the credential schema
+
+**Request body**
+```bash
+{ "schema":
+  { "name":{name},
+    "organization_ids" : [{organisation_id}, ...]
+  }
+}
+ ```
+* `name` – Name of the credential schema
+* `organization_id` - List of organisation IDs. Organisations where this credential schema can be used (optional)
+
+
 
 **Response**
 
-The updated credential schema object.
+The updated credential schema object.  
 
 ## Read Verifiable Credential JSON Schema
 
@@ -128,9 +172,8 @@ GET /schemas/{id}/{version}/schema.json
 ```
 
 **Request**
-
-* Id – ID of the Credential Schema
-* Version – Version of the credential schema
+* `id` – ID of the Credential Schema
+* `version` – Version of the credential schema
 
 **Response**
 

--- a/guides/api-guides/credentials/credential-types.md
+++ b/guides/api-guides/credentials/credential-types.md
@@ -1,6 +1,6 @@
 # Credential Types
 
-Credential types enable Organisations to select a [Credential Schema](credential-schemas.md) when preparing credentials to be issued. They also allow Organisations to define the visual appearance of the credential which can reflect the Organisation's branding requirements. Credential types are used in both the Meeco Enterprise Portal and Meeco Wallet. Please note that in the Enterprise Portal, credential types are referred to as Credential Templates.
+Credential types enable Organisations to select a [Credential Schema](credential-schemas.md) when preparing credentials to be issued. They also allow Organisations to define the visual appearance of the credential which can reflect the Organisation's branding requirements. Credential types are used in both the Meeco Enterprise Portal. Please note that in the Enterprise Portal, credential types are referred to as Credential Templates.
 
 ## Prerequisites
 
@@ -20,14 +20,27 @@ Creation of a credential type.
 POST /credential_types
 ```
 
-**Request**
+**Request body**
 
-* Name – Name of the credential type
-* Credential Schema - The associated credential schema
-* Style
-  * Text Colour
-  * Background Colour – Background colour for the credential (CSS styles supported)
-  * Logo – Logo displayed in the top left corner of the credential
+```bash
+{ "credential_type":
+  { "name":{name},
+    "schema_id":{credential_schema_id},
+    "format":{format},
+    "config":{config},
+    "style":{"text-color":{text_color},"background":{background_color}, "logo": {logo}}    
+  }
+}
+```
+
+- `name` – Name of the credential type
+- `credential_schema_id` - The associated credential schema ID
+- `format` - Format of the credential i.e. sd+vc-json
+- `config` - This attribute allows to define disclosure_frame, vct, expiry, issuer_credential_configurations_supported_name (optional)
+- `style`
+  - `text_color` – Text colour for the credential (CSS styles supported)
+  - `background_color` – Background colour for the credential (CSS styles supported)
+  - `logo` – Logo displayed in the top left corner of the credential (optional)
 
 **Response**
 

--- a/guides/api-guides/credentials/issue-credentials.md
+++ b/guides/api-guides/credentials/issue-credentials.md
@@ -55,7 +55,7 @@ The request contains the following data:
   * `issuer`
     * `id` – Issuer ID
     * `name` – Name of the issuer (optional)
-* `claims` – Claims for the subject
+* `claims` – Claims of the subject
 * `disclosure_frame` - Disclosure frame for vc+sd-jwt format credential (optional)
 * `cnf` - VC JWKs configuration. 
 * `revokable` – If true, the generated credential can be revoked later on.

--- a/guides/api-guides/credentials/issue-credentials.md
+++ b/guides/api-guides/credentials/issue-credentials.md
@@ -14,7 +14,6 @@ The following items are required in order for a credential to be created and iss
 
 * [Credential Schema](credential-schemas.md) – the [data schema](https://www.w3.org/TR/vc-data-model/#data-schemas) of the credential
 * [Credential Type](credential-types.md)
-* [DID](../dids/did-methods.md)
 
 ## Who can undertake this operation?
 
@@ -30,21 +29,42 @@ Generating a credential requires issuance data and data related to the credentia
 POST /credentials/generate
 ```
 
-**Request**
+**Request body**
+```bash
+{
+  "credential": {
+  "credential_type_id": {credential_type_id},
+  "issuer": {
+  "id": {issuer_id},
+  "name": {issuer_name}
+  },
+  "claims": {
+    {claim_1}: {claim1_value} 
+  },
+  "disclosure_frame": {disclosure_frame}
+  "cnf": {cnf},
+  "revocable": {revokable},
+  "expires_at": {expires_at},
+  "type": {type}
+}
+```
 
 The request contains the following data:
-* [Credential Type](credential-types.md)
-* Issuer
-  * DID – Fully qualified DID string
-  * Name – Name of the issuer (optional)
-* Claims – Maps to the `credentialSubject` attribute of a credential
-  * Subject DID – Typically, the `id` property contains the DID of the subject
-* Expiration date – Datetime after which the credential expires
-* Revocable – If true, the generated credential can be revoked later on.
+* `credential`
+  * [`credential_type_id`](credential-types.md)
+  * `issuer`
+    * `id` – Issuer ID
+    * `name` – Name of the issuer (optional)
+* `claims` – Claims for the subject
+* `disclosure_frame` - Disclosure frame for vc+sd-jwt format credential (optional)
+* `cnf` - VC JWKs configuration. 
+* `revokable` – If true, the generated credential can be revoked later on.
+* `expires_at` – Datetime after which the credential expires. Default: false
+
 
 **Response**
 
 The response is the credential object that is generated. This contains:
 * ID of the credential
-* Unsigned credential in `vc-jwt` data format
+* Unsigned credential
 * Metadata

--- a/guides/api-guides/credentials/presentation-definitions.md
+++ b/guides/api-guides/credentials/presentation-definitions.md
@@ -2,11 +2,6 @@
 
 Presentation definitions define which credential(s) a Verifier requests and for what purpose. Each selected credential is comprised of a [credential schema](credential-schemas.md) and the associated Issuer. The resulting object is conformant with the [W3C Presentation Exchange 1.0](https://identity.foundation/presentation-exchange/spec/v1.0.0/) specification and is used when generating a [Verification Request](../oidc/oidc4vp.md).
 
-## Prerequisites
-
-* [Verifiable Credential JSON Schema](credential-schemas.md)
-* [Issuer DID](dids/did-methods.md) (optional)
-
 ## Who can undertake this operation?
 
 A presentation definiton is created by an Organisation.
@@ -21,15 +16,43 @@ Creation of a presentation definitions for an Organisation.
 POST /presentation_definitions
 ```
 **Request**
+* `Meeco-Organisation-ID` - An organisation ID where the presentation definition is available to.  (header)
 
-* Organisation (header)
-* Name
-* Purpose
-* List of required credentials. For each, the following is defined:
-  * Name
-  * Purpose
-  * Verifiable Credential JSON Schema URL
-  * Issuer DID
+**Request body**  
+```bash
+{
+    "presentation_definition": {
+        "name": {name},
+        "purpose": {purpose},
+        "input_descriptors": [
+            {
+                "id": {id},
+                "format": {
+                    {format}: {
+                        "alg": [
+                            {algorithm}
+                        ]
+                    }
+                },
+                "purpose": {purpose},
+                "constraints": {
+                    "limit_disclosure": "preferred",
+                    "fields": [{path}]
+                }
+            }
+        ]
+    }
+}
+```
+
+
+* `name`
+* `purpose`
+* `input_descriptors` - Containing list of required credentials. For each, the following is defined:
+  * `name`
+  * `purpose`
+  * `format`
+  * `constraints` - List of requested fields
 
 **Response**
 
@@ -48,9 +71,12 @@ GET /presentation_definitions
 ```
 **Request**
 
-* Organisation (header)
-* Filters (optional):
-  * Status
+* `Meeco-Organisation-ID` (header)
+* Query parameters (optional):
+i.e. 
+  * `status` - To filter archived presentation definitions. Enum: "all" "active" "archived"
+  * `search` - Search by name
+
 
 **Response**
 
@@ -67,8 +93,9 @@ POST /presentation_definitions/{id}
 ```
 **Request**
 
-* Presentation Definition ID
-* Organisation (header)
+* `Meeco-Organisation-ID` (header)
+* `id` - Presentation Definition ID
+
 
 **Response**
 
@@ -81,12 +108,12 @@ A presentation definition can be archived and restored. When a presentation defi
 **Endpoint**
 
 ```bash
-PUT /presentation_definitions/{id}
+POST /presentation_definitions/{id}/archive
 ```
 **Request**
 
-* Presentation Definition ID
-* Organisation (header)
+* `Meeco-Organisation-ID` (header)
+* `id` - Presentation Definition ID
 
 **Response**
 
@@ -105,8 +132,8 @@ GET /presentation_definitions/{id}/definition.json
 ```
 **Request**
 
-* Presentation Definition ID
-* Organisation (header)
+* `Meeco-Organisation-ID` (header)
+* `id` - Presentation Definition ID
 
 **Response**
 


### PR DESCRIPTION
Updated the following pages:
* Credential Schema
* Credential types
* Issue credential
* Presentation definition

I was not too sure whether we should keep the following:
* Issue credential
* Presentation

Since those endpoints are something that can be done through OCW, I am unsure if we want to keep that in this documentation or not.
Portal is also removing this feature - should we remove this from the documentation? 
This can be still checked in the API documentation.